### PR TITLE
Add async library

### DIFF
--- a/IronScheme/IronScheme.Console/lib/ironscheme/async.sls
+++ b/IronScheme/IronScheme.Console/lib/ironscheme/async.sls
@@ -1,0 +1,66 @@
+#| License
+Copyright (c) 2022 Robby Zambito
+All rights reserved.
+This source code is subject to terms and conditions of the BSD License.
+See docs/license.txt. |#
+
+(library (ironscheme async)
+  (export async-lambda
+   	  await
+	  define-async
+	  start
+	  started?
+	  status
+	  task?)
+  (import (ironscheme)
+	  (ironscheme clr))
+
+  (clr-using System.Threading.Tasks)
+  (clr-using System.Runtime.CompilerServices)
+
+  (define-syntax define-async
+    (syntax-rules (->)
+      ((_ (name params ...) -> ret-type body1 body2 ...)
+       (define name
+	 (async-lambda (params ...) -> ret-type
+		       body1
+		       body2 ...)))
+      ((_ (name params ...) body1 body2 ...)
+       (define name
+	 (async-lambda (params ...)
+		       body1
+		       body2 ...)))))
+
+  (define (started? task)
+    ;; Created is the only status where it has not yet been started.
+    (not (equal? (status task) 'Created)))
+
+  (define (status task)
+    (clr-prop-get Task Status task))
+
+  ;; Construct a Task
+  (define-syntax async-lambda
+    (syntax-rules (->)
+      ((_ (params ...) -> ret-type body1 body2 ...)
+       (lambda (params ...)
+	 (clr-new (Task ret-type)
+		  (lambda ()
+		    body1
+		    body2 ...))))
+      ((_ (params ...) body1 body2 ...)
+       (async-lambda (params ...) -> Object body1 body2 ...))))
+  
+  ;; Await the task and return the result.
+  (define (await task)
+    (start task)
+    (clr-call (TaskAwaiter Object) GetResult (clr-call (Task Object) GetAwaiter task)))
+
+  ;; Can be called any number of times without error, unlike Task.Start()
+  ;; Returns the started task.
+  (define (start task)
+    (unless (started? task)
+      (clr-call Task Start task))
+    task)
+
+  (define (task? obj)
+    (clr-is Task obj)))

--- a/IronScheme/IronScheme.Console/lib/ironscheme/async.sls
+++ b/IronScheme/IronScheme.Console/lib/ironscheme/async.sls
@@ -43,7 +43,7 @@ See docs/license.txt. |#
     (syntax-rules (->)
       ((_ (params ...) -> ret-type body1 body2 ...)
        (lambda (params ...)
-	 (clr-new (Task ret-type)
+	 (clr-new (System.Threading.Tasks.Task ret-type)
 		  (lambda ()
 		    body1
 		    body2 ...))))


### PR DESCRIPTION
This library wraps some of the features of [Tasks](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task?view=net-7.0) to support some basic async/await style concurrency in IronScheme.

Here is an example of using the library:

```scheme
(import (ironscheme async) (srfi :41))

(define-async (sum-range lower upper)
  (stream-fold + 0 (stream-take (- upper lower) (stream-from lower))))

(define-async (sum-of-sum-ranges1)
  (let ((a (sum-range 10000 10000000))
	(b (sum-range 10000 10000000))
	(c (sum-range 10000 10000000)))
    (+ (await a)
       (await b)
       (await c))))

(define-async (sum-of-sum-ranges2)
  (let ((a (sum-range 10000 10000000))
	(b (sum-range 10000 10000000))
	(c (sum-range 10000 10000000)))
    (start a)
    (start b)
    (start c)
    (+ (await a)
       (await b)
       (await c))))
```

```scheme
> (time (await (sum-of-sum-ranges1)))
Statistics for '(await (sum-of-sum-ranges1))':
  Real Time:  60463ms
  CPU Time:   59890ms
  User Time:  60400ms
  GC's:       7923
149999835015000
> (time (await (sum-of-sum-ranges2)))
Statistics for '(await (sum-of-sum-ranges2))':
  Real Time:  30184ms
  CPU Time:   65350ms
  User Time:  66120ms
  GC's:       7941
149999835015000
```

#85 